### PR TITLE
Fix signed safemath

### DIFF
--- a/contracts/math/SafeMath.sol
+++ b/contracts/math/SafeMath.sol
@@ -27,16 +27,15 @@ library SafeMath {
   /**
   * @dev Multiplies two signed integers, throws on overflow.
   */
-  function mul(int256 a, int256 b) internal pure returns (int256) {
+  function mul(int256 a, int256 b) internal pure returns (int256 c) {
     // Gas optimization: this is cheaper than asserting 'a' not being zero, but the
     // benefit is lost if 'b' is also tested.
     // See: https://github.com/OpenZeppelin/openzeppelin-solidity/pull/522
     if (a == 0) {
       return 0;
     }
-    int256 c = a * b;
+    c = a * b;
     assert((a != -1 || b != INT256_MIN) && c / a == b);
-    return c;
   }
 
   /**
@@ -70,10 +69,9 @@ library SafeMath {
   /**
   * @dev Subtracts two signed integers, throws on overflow.
   */
-  function sub(int256 a, int256 b) internal pure returns (int256) {
-    int256 c = a - b;
+  function sub(int256 a, int256 b) internal pure returns (int256 c) {
+    c = a - b;
     assert((b >= 0 && c <= a) || (b < 0 && c > a));
-    return c;
   }
 
   /**
@@ -88,9 +86,8 @@ library SafeMath {
   /**
   * @dev Adds two signed integers, throws on overflow.
   */
-  function add(int256 a, int256 b) internal pure returns (int256) {
-    int256 c = a + b;
+  function add(int256 a, int256 b) internal pure returns (int256 c) {
+    c = a + b;
     assert((b >= 0 && c >= a) || (b < 0 && c < a));
-    return c;
   }
 }

--- a/contracts/math/SafeMath.sol
+++ b/contracts/math/SafeMath.sol
@@ -52,7 +52,7 @@ library SafeMath {
   * @dev Integer division of two signed integers, truncating the quotient.
   */
   function div(int256 a, int256 b) internal pure returns (int256) {
-    // assert(b > 0); // Solidity automatically throws when dividing by 0
+    // assert(b != 0); // Solidity automatically throws when dividing by 0
     // Overflow only happens when the smallest negative int is multiplied by -1.
     assert(a != INT256_MIN || b != -1);
     return a / b;

--- a/contracts/math/SafeMath.sol
+++ b/contracts/math/SafeMath.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.4.24;
  * @dev Math operations with safety checks that throw on error
  */
 library SafeMath {
+  int256 constant INT256_MIN = int256((uint256(1) << 255));
 
   /**
   * @dev Multiplies two unsigned integers, throws on overflow.
@@ -34,7 +35,7 @@ library SafeMath {
       return 0;
     }
     int256 c = a * b;
-    assert(c / a == b);
+    assert((a != -1 || b != INT256_MIN) && c / a == b);
     return c;
   }
 
@@ -54,7 +55,6 @@ library SafeMath {
   function div(int256 a, int256 b) internal pure returns (int256) {
     // assert(b > 0); // Solidity automatically throws when dividing by 0
     // Overflow only happens when the smallest negative int is multiplied by -1.
-    int256 INT256_MIN = int256((uint256(1) << 255));
     assert(a != INT256_MIN || b != -1);
     return a / b;
   }

--- a/test/math/SafeMath.test.js
+++ b/test/math/SafeMath.test.js
@@ -187,6 +187,7 @@ contract('SafeMath', () => {
         const b = new BigNumber(-1);
 
         await assertJump(this.safeMath.mulInts(a, b));
+        await assertJump(this.safeMath.mulInts(b, a));
       });
     });
 


### PR DESCRIPTION
I also have a proof of correctness here:

---

Let +, -, * be the usual arithemetic operators on the integers, and / be integer division.

Let the integers in the range [-2^255, 2^255-1] be the space of int256s

Given int256s a and b, define a OP b overflows iff a OP b is not in int256s

Let ⊕, ⊖, ⊗, ⊘ be corresponding operators on int256s, where WLOG for all operators, a ⊕ b is equivalent to a + b (mod 2^256)

Note that WLOG for all operators, a + b == a ⊕ b iff a + b doesn't overflow.

---

* Assume int256s a, b
  * Assume b < 0
    * a + b < a
    * Assume a + b doesn't overflow
      * a ⊕ b == a + b < a
    * Assume a + b overflows
      * Either a + b < -2^255 or a + b > 2^255-1
      * a + b < a <= 2^255-1 means a + b < -2^255
      * -2^255 <= a < -2^255 - b <= 0 (due to int256 bounds for a and b)
      * -2^255 - 2^255 <= a + b < -2^255
      * 0 <= a + b + 2^256 < 2^255 is contained in int256
      * a ⊕ b == a + (b + 2^256) >= a + 2^255 >= a
    * a + b doesn't overflow iff a ⊕ b < a
  * Assume b >= 0
    * a + b >= a
    * Assume a + b doesn't overflow
      * a ⊕ b == a + b >= a
    * Assume a + b overflows
      * Either a + b < -2^255 or a + b > 2^255-1
      * a + b >= a >= -2^255 means a + b > 2^255-1
      * 2^255-1 >= a > 2^255-1 - b >= 0 (due to int256 bounds for a and b)
      * 2^255-1 + 2^255-1 >= a + b > 2^255-1
      * -2 >= a + b - 2^256 > -2^255 is contained in int256
      * a ⊕ b == a + (b - 2^256) <= a - 2^255 - 1 < a
    * a + b doesn't overflow iff a ⊕ b >= a

  * (b < 0 and a ⊕ b < a) or (b >= 0 and a ⊕ b >= a) implies a + b doesn't overflow

---

* Assume int256s a, b
  * a - b == a + (-b)
  * Assume b != -2^255
    * a ⊖ b == a ⊕ (-b)
    * (-b < 0 and a ⊕ -b < a) or (-b >= 0 and a ⊕ -b >= a) implies a - b doesn't overflow
    * (b > 0 and a ⊖ b < a) or (b <= 0 and a ⊖ b >= a) implies a - b doesn't overflow
  * Assume b == -2^255
    * b <= 0 (from assumption)
    * Assume a - b overflows
      * Either a - b < -2^255 or a - b > 2^255-1
      * -2^255 <= 0 <= a - b == a + 2^255, so a - b == a + 2^255 > 2^255-1
      * 2^255-1 < a - b < 2^255 + 2^255-1
      * -1 < a < 2^255-1
      * a ⊖ b == a - b - 2^256 == a - 2^255 < a
    * a - b overflows implies a ⊖ b < a
    * a ⊖ b >= a implies a - b doesn't overflow (via contrapositive)
    * (b > 0 and a ⊖ b < a) or (b <= 0 and a ⊖ b >= a) implies a - b doesn't overflow
  * (b > 0 and a ⊖ b < a) or (b <= 0 and a ⊖ b >= a) implies a - b doesn't overflow via case analysis

---

* For integers a and b where b != 0, abs(a / b) == abs(a) / abs(b)

* Assume int256s a, b where b != 0
  * abs(b) >= 1
  * Assume a != -2^255
    * a is in the range [-(2^255-1), 2^255-1]
    * abs(a) <= 2^255-1
    * abs(a / b) == abs(a) / abs(b) <= abs(a) / 1 == abs(a) <= 2^255-1
    * a / b is in the range [-(2^255-1), 2^255-1]
    * a / b doesn't overflow
  * Assume a == -2^255
    * Assume abs(b) > 1
      * abs(a / b) == abs(a) / abs(b) < abs(a) / 1 == abs(a) == -2^255
      * a / b is in the range [-(2^255-1), 2^255-1]
      * a / b doesn't overflow
    * Assume b == 1
      * a / b == -2^255 is an int256
      * a / b doesn't overflow
    * Assume b == -1
      * a / b == 2^255 is not an int256
      * a / b overflows

  * a / b doesn't overflow (a / b == a ⊘ b) iff a != -2^255 or b != -1

---

* Assume int256s a, b, (we want find necessary and sufficient conditions for when a * b doesn't overflow)
  * Assume a == 0
    * a * b == 0 doesn't overflow
  * Assume a != 0
    * a * b / a == b
    * Assume a * b doesn't overflow
      * a * b == a ⊗ b is an int256
      * a ⊗ b / a == b is an int256 (doesn't overflow)
      * a * b / a == a ⊗ b ⊘ a == b
    * Assume a ⊗ b ⊘ a == b
      * Assume a ⊗ b == -2^255, and a == -1 (⊘ overflows in a ⊗ b ⊘ a)
        * Assume a * b doesn't overflow
          * -1 ⊗ b == -1 * b == -2^255
          * b == 2^255
          * Contradiction: but b is an int256, therefore...
        * a * b overflows
        * a * b == -1 * b not an int256
        * b == -2^255 (this is the only int256 for which the above condition holds)
      * Assume ⊘ doesn't overflow in a ⊗ b ⊘ a
        * a ⊗ b ⊘ a == a ⊗ b / a == b
        * a ⊗ b == a * b
        * a * b == 0 doesn't overflow

  * a * b doesn't overflow (a * b == a ⊗ b) iff (a != -1 or b != -2^255) and (a == 0 or a ⊗ b ⊘ a == b)